### PR TITLE
Use browser context instead of page when initializing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,16 @@
 const Controller = require('happo-e2e/controller');
+const pathToBrowserBuild = require.resolve('happo-e2e/browser.build.js');
 
 const controller = new Controller();
 
 module.exports = {
-  async init(page) {
-    await page.addInitScript({
-      path: './node_modules/happo-e2e/browser.build.js',
-    });
-    await page.evaluate(() => {
+  async init(context) {
+    await context.addInitScript({ path: pathToBrowserBuild });
+    await context.addInitScript(`
       window.addEventListener('load', () => {
         window.happoTakeDOMSnapshot.init(window);
       });
-    });
+    `);
     await controller.init();
   },
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ module.exports = {
   },
 
   async screenshot(page, handleOrLocator, { component, variant }) {
+    if (!controller.isActive()) {
+      return;
+    }
     if (!component) {
       throw new Error('Missing `component`');
     }

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ const pathToBrowserBuild = require.resolve('happo-e2e/browser.build.js');
 const controller = new Controller();
 
 module.exports = {
-  async init(context) {
-    await context.addInitScript({ path: pathToBrowserBuild });
-    await context.addInitScript(`
+  async init(contextOrPage) {
+    await contextOrPage.addInitScript({ path: pathToBrowserBuild });
+    await contextOrPage.addInitScript(`
       window.addEventListener('load', () => {
         window.happoTakeDOMSnapshot.init(window);
       });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "react-dom": "^17.0.2"
   },
   "dependencies": {
-    "happo-e2e": "^1.0.0-rc.2"
+    "happo-e2e": "^1.0.3"
   }
 }

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -1,8 +1,8 @@
 const { test, expect } = require('@playwright/test');
 const happoPlaywright = require('../');
 
-test.beforeEach(async ({ page }) => {
-  await happoPlaywright.init(page);
+test.beforeEach(async ({ context }) => {
+  await happoPlaywright.init(context);
 });
 
 test.afterEach(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,10 +2076,10 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-happo-e2e@^1.0.0-rc.2:
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-1.0.0-rc.2.tgz#4552b543c4e59efd85bffe75f3c43d313af999ad"
-  integrity sha512-JTegxzWIvI65H3ByeV7FB2r64FXe+pghTveTPf/lCJJeOQLJeMtBA1iO328zSLQOatSy+WZHI1Nxy1fODNyyeQ==
+happo-e2e@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-1.0.3.tgz#4f8c2a28d078344f446938f2c271d4d6baab6de0"
+  integrity sha512-cfA3wPYrpW3xXjGxKRydw4diuqgHgdsJlqrVzpxAXT/553RIK40w+cPkNxx+yO/rSvU4Ttp5NccM7XKPryVoiA==
   dependencies:
     archiver "^5.3.0"
     base64-stream "^1.0.0"


### PR DESCRIPTION
The browser context will ensure all pages are prepped with the right happo functions. Not just the current page and all pages navigated to. 