### PR TITLE
Move happo-e2e to peerDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .next
 yarn-error.log
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "happo.io": "^6.8.0",
     "next": "^12.0.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "happo-e2e": "^1.4.2"
   },
-  "dependencies": {
-    "happo-e2e": "^1.0.3"
+  "peerDependencies": {
+    "happo-e2e": "^1.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,15 +2076,16 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-happo-e2e@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-1.0.3.tgz#4f8c2a28d078344f446938f2c271d4d6baab6de0"
-  integrity sha512-cfA3wPYrpW3xXjGxKRydw4diuqgHgdsJlqrVzpxAXT/553RIK40w+cPkNxx+yO/rSvU4Ttp5NccM7XKPryVoiA==
+happo-e2e@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-1.4.2.tgz#e562896ff34e0482abd26d3ee1bcf167e39b551f"
+  integrity sha512-aHKzbMgTAjryWJ8Qv2Bzk3dBWo1AUwFpruaS4YZab03sKzRaeB4NdPAR77HhyxxrOYqpuheZjJfoNJ7CxmUUSA==
   dependencies:
     archiver "^5.3.0"
     base64-stream "^1.0.0"
     crypto-js "^4.1.1"
     https-proxy-agent "^5.0.0"
+    image-size "^1.0.1"
     mkdirp "^1.0.4"
     node-fetch "^2.0.0"
     parse-srcset "^1.0.2"
@@ -2270,6 +2271,13 @@ image-size@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.0.tgz#58b31fe4743b1cec0a0ac26f5c914d3c5b2f0750"
   integrity sha512-JLJ6OwBfO1KcA+TvJT+v8gbE6iWbj24LyDNFgFEN0lzegn6cC6a/p3NIDaepMsJjQjlUWqIC7wJv8lBFxPNjcw==
+  dependencies:
+    queue "6.0.2"
+
+image-size@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
+  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
   dependencies:
     queue "6.0.2"
 


### PR DESCRIPTION
This was always the intention. By having it separately, we can make updates to happo-e2e without having to bump version here.