### PR TITLE
Allow happo-e2e@v2 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   "devDependencies": {
     "@playwright/test": "^1.16.3",
     "eslint": "^8.2.0",
+    "happo-e2e": "^2.0.1",
     "happo.io": "^6.8.0",
     "next": "^12.0.4",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "happo-e2e": "^1.4.2"
+    "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "happo-e2e": "^1.4.2"
+    "happo-e2e": ">=1.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2076,10 +2076,10 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-happo-e2e@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-1.4.2.tgz#e562896ff34e0482abd26d3ee1bcf167e39b551f"
-  integrity sha512-aHKzbMgTAjryWJ8Qv2Bzk3dBWo1AUwFpruaS4YZab03sKzRaeB4NdPAR77HhyxxrOYqpuheZjJfoNJ7CxmUUSA==
+happo-e2e@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-2.0.1.tgz#2a7d8c15375ea19e0df991de1e43cb197c28803e"
+  integrity sha512-Gmi22Oi3Pw6IZbfzI505Cdat1uXZo69gt/Moy9oXMw+f0yDnF+jPfpwUx/f9ammVgRUkymMVbMOEvWV/T8/hKQ==
   dependencies:
     archiver "^5.3.0"
     base64-stream "^1.0.0"


### PR DESCRIPTION
Also update the dev dependency to the latest version. I want to figure out if a fix I recently made in happo-e2e (spaces in urls) works.