### PR TITLE
Simplify setup in happoPlaywright.init

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Run tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Start dev server in the background
+        run: yarn dev &
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+
+      - name: Run tests
+        run: yarn test
+        env:
+          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}

--- a/index.js
+++ b/index.js
@@ -6,11 +6,6 @@ const controller = new Controller();
 module.exports = {
   async init(contextOrPage) {
     await contextOrPage.addInitScript({ path: pathToBrowserBuild });
-    await contextOrPage.addInitScript(`
-      window.addEventListener('load', () => {
-        window.happoTakeDOMSnapshot.init(window);
-      });
-    `);
     await controller.init();
   },
 

--- a/tests/app.spec.js
+++ b/tests/app.spec.js
@@ -1,11 +1,11 @@
 const { test, expect } = require('@playwright/test');
 const happoPlaywright = require('../');
 
-test.beforeEach(async ({ context }) => {
-  await happoPlaywright.init(context);
+test.beforeAll(async () => {
+  await happoPlaywright.init();
 });
 
-test.afterEach(async () => {
+test.afterAll(async () => {
   await happoPlaywright.finish();
 });
 


### PR DESCRIPTION
By lazy-loading the `takeDOMSnapshot` function, we can remove the need to pass in a page or context in `beforeAll`. 