### PR TITLE
Simplify usage of library

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,41 +1,22 @@
 import Controller from 'happo-e2e/controller';
 import type { Page, ElementHandle, Locator } from '@playwright/test';
+import { test } from '@playwright/test';
 
 const pathToBrowserBuild = require.resolve('happo-e2e/browser.build.js');
 
 const controller = new Controller();
 
-async function lazyLoadBrowserBundle(page: Page) {
-  if (
-    await page.evaluate(() => typeof window.happoTakeDOMSnapshot === 'undefined')
-  ) {
-    await page.addScriptTag({ path: pathToBrowserBuild });
-
-    // Add timeout check for happoTakeDOMSnapshot
-    try {
-      await page.waitForFunction(
-        () => typeof window.happoTakeDOMSnapshot !== 'undefined',
-        { timeout: 10000 },
-      );
-    } catch {
-      throw new Error('Timed out waiting for happoTakeDOMSnapshot to be defined');
-    }
-  }
-}
-
-export async function init(pageOrContext?: never) {
-  if (pageOrContext) {
-    console.warn(
-      '[HAPPO] You no longer need to pass a page or context to happoPlaywright.init()',
-    );
-  }
-
+test.beforeAll(async () => {
   await controller.init();
-}
+});
 
-export async function finish() {
+test.afterAll(async () => {
   await controller.finish();
-}
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript({ path: pathToBrowserBuild });
+});
 
 export async function screenshot(
   page: Page,
@@ -72,8 +53,6 @@ export async function screenshot(
   if (!variant) {
     throw new Error('Missing `variant`');
   }
-
-  await lazyLoadBrowserBundle(page);
 
   const elementHandle =
     'elementHandle' in handleOrLocator

--- a/src/tests/app.spec.ts
+++ b/src/tests/app.spec.ts
@@ -9,14 +9,6 @@ function assertError(error: unknown): asserts error is Error {
   }
 }
 
-test.beforeAll(async () => {
-  await happoPlaywright.init();
-});
-
-test.afterAll(async () => {
-  await happoPlaywright.finish();
-});
-
 test('basic test', async ({ page }) => {
   expect(process.env.HAPPO_API_KEY).toBeDefined();
   expect(process.env.HAPPO_API_SECRET).toBeDefined();

--- a/src/tests/app2.spec.ts
+++ b/src/tests/app2.spec.ts
@@ -1,0 +1,13 @@
+import { test } from './fixture';
+import * as happoPlaywright from '..';
+
+test('basic test', async ({ page }) => {
+  await page.goto('http://localhost:7676');
+
+  const body = page.locator('body');
+
+  await happoPlaywright.screenshot(page, body, {
+    component: 'Body',
+    variant: 'inside app2',
+  });
+});

--- a/src/tests/fixture.ts
+++ b/src/tests/fixture.ts
@@ -1,0 +1,4 @@
+import { test as base } from '@playwright/test';
+
+// Empty fixture to allow importing the fixture in other files
+export const test = base.extend({});


### PR DESCRIPTION
This is a breaking change. Instead of having everyone add their own beforeAll/afterAll hooks, we can do it for them. This makes the only export from the library `screenshot`. As long as you use `screenshot`, the relevant hooks will be set up for you.

This will also fix an issue where the happo-e2e library can't monkey-patch certain browser APIs. By using a beforeEach, we can ensure that the browser bundle is always injected as an init script.