### PR TITLE
Update .npmignore to exclude more tests and eslint config

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,11 +1,11 @@
-.eslintrc.js
+**/tests
 .github
 .happo.js
 .next
 .node-version
+eslint.config.*
 node_modules
 pages
 test-results
-tests/*
+tests
 yarn-error.log
-


### PR DESCRIPTION
This helps our package avoid including some files that are not very useful for consumers.